### PR TITLE
Specify full path top top tier README

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -982,7 +982,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = README.md
+USE_MDFILE_AS_MAINPAGE = ./README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing


### PR DESCRIPTION
Smallest code review ever. Changed README.md to ./README.md in doxyfile to ensure doxygen pulls the write file for the website index page.

