### PR TITLE
Add GBP parameter to allow/prohibit replanning

### DIFF
--- a/global_body_planner/global_body_planner.yaml
+++ b/global_body_planner/global_body_planner.yaml
@@ -7,6 +7,7 @@ global_body_planner:
   committed_horizon: 0     # Committed duration of current plan (replan starting from state in current plan this far ahead), s
   state_error_threshold: 10 #0.25
   startup_delay: 1.0   # Time to delay after starting node before planning
+  replanning: true    # Boolean to determine if replanning is allowed
   H_MAX: 0.375         # Maximum height of leg base, m
   H_MIN: 0.125         # Minimum ground clearance of body corners, m
   V_MAX: 3.0           # Maximum robot velocity, m/s (4.0 for cheetah, 2.5 for anymal)

--- a/global_body_planner/include/global_body_planner/global_body_planner.h
+++ b/global_body_planner/include/global_body_planner/global_body_planner.h
@@ -99,6 +99,11 @@ class GlobalBodyPlanner {
      */
     void waitForData();
 
+    /**
+     * @brief Call the planner repeatedly until startup_delay has been reached then return
+     */
+    void getInitialPlan();
+
     /// Subscriber for terrain map messages
     ros::Subscriber terrain_map_sub_;
 
@@ -200,6 +205,9 @@ class GlobalBodyPlanner {
 
     /// Delay after node startup before planning and publishing
     double startup_delay_;
+
+    /// Boolean for whether replanning is allowed
+    bool replanning_allowed_;
 
 };
 

--- a/global_body_planner/src/global_body_planner.cpp
+++ b/global_body_planner/src/global_body_planner.cpp
@@ -25,6 +25,7 @@ GlobalBodyPlanner::GlobalBodyPlanner(ros::NodeHandle nh) {
   nh.param<double>("global_body_planner/committed_horizon", committed_horizon_, 0);
   nh.param<double>("global_body_planner/state_error_threshold", state_error_threshold_, 0.5);
   nh.param<double>("global_body_planner/startup_delay", startup_delay_, 0.0);
+  nh.param<bool>("global_body_planner/replanning", replanning_allowed_, true);
 
   nh.param<std::vector<double> >("global_body_planner/start_state", start_state_, start_state_default);
   nh.param<std::vector<double> >("global_body_planner/goal_state", goal_state_, goal_state_default);
@@ -61,6 +62,12 @@ GlobalBodyPlanner::GlobalBodyPlanner(ros::NodeHandle nh) {
   spirit_utils::loadROSParam(nh,"global_body_planner/BACKUP_RATIO", planner_config_.BACKUP_RATIO);
   spirit_utils::loadROSParam(nh,"global_body_planner/NUM_GEN_STATES", planner_config_.NUM_GEN_STATES);
   spirit_utils::loadROSParam(nh,"global_body_planner/GOAL_BOUNDS", planner_config_.GOAL_BOUNDS);
+
+  // If replanning is prohibited, set committed horizon to zero ()
+  if (replanning_allowed_ == false && committed_horizon_ > 0) {
+    committed_horizon_ = 0;
+    ROS_INFO("Replanning is prohibited, setting committed horizon to zero");
+  }
 
 }
 
@@ -137,7 +144,6 @@ void GlobalBodyPlanner::updateRestartFlag() {
     return;
   }
 
-  double state_error_threshold = 0.5;
   std::vector<double> current_state_in_plan_ = body_plan_.front();
   if (poseDistance(robot_state_, current_state_in_plan_) > state_error_threshold_) {
     restart_flag_ = true;
@@ -382,6 +388,7 @@ void GlobalBodyPlanner::publishPlan() {
   // Publish both interpolated body plan and discrete states
   body_plan_pub_.publish(body_plan_msg);
   discrete_body_plan_pub_.publish(discrete_body_plan_msg);
+
 }
 
 void GlobalBodyPlanner::waitForData() {
@@ -401,20 +408,30 @@ void GlobalBodyPlanner::waitForData() {
   }
 }
 
+void GlobalBodyPlanner::getInitialPlan() {
+
+  // Keep track of when the planner started
+  ros::Time start_time = ros::Time::now();
+
+  // Repeatedly call the planner until the startup delay has elapsed
+  while (ros::ok() && ((ros::Time::now() - start_time) < ros::Duration(startup_delay_))) {
+    callPlanner();
+  }  
+}
+
 void GlobalBodyPlanner::spin() {
 
   ros::Rate r(update_rate_);
   waitForData();
-
-  ros::Time start_time = ros::Time::now();
+  getInitialPlan();
+  publishPlan();
+  
   while (ros::ok()) {
 
-    if ((ros::Time::now() - start_time) >= ros::Duration(startup_delay_)) {
-      // Update the plan
+    if (replanning_allowed_) {
+      // Continue updating and publishing the plan
       callPlanner();
       publishPlan();
-    } else {
-      ROS_INFO_THROTTLE(1/startup_delay_, "Waiting to start GBP...");
     }
 
     // Sleep

--- a/global_body_planner/src/global_body_planner.cpp
+++ b/global_body_planner/src/global_body_planner.cpp
@@ -422,19 +422,25 @@ void GlobalBodyPlanner::getInitialPlan() {
 void GlobalBodyPlanner::spin() {
 
   ros::Rate r(update_rate_);
+
+  // Once we get map and state data, start planning until startup delay is up
   waitForData();
   getInitialPlan();
+
+  // Set the timestamp for the initial plan to now and publish
+  plan_timestamp_ = ros::Time::now();
   publishPlan();
   
+  // Enter main spin
   while (ros::ok()) {
 
+    // IF allowed, continue updating and publishing the plan
     if (replanning_allowed_) {
-      // Continue updating and publishing the plan
       callPlanner();
       publishPlan();
     }
 
-    // Sleep
+    // Process callbacks and sleep
     ros::spinOnce();
     r.sleep();
   }


### PR DESCRIPTION
This should make testing low level systems easier to not have to deal with GBP replanning in the middle of a run.